### PR TITLE
chore: add CI Dependabot review reminder

### DIFF
--- a/.github/workflows/deps-review-instruction.yml
+++ b/.github/workflows/deps-review-instruction.yml
@@ -2,6 +2,7 @@ name: Deps Review Instruction
 
 permissions:
   pull-requests: write
+  
 
 on: 
   pull_request:


### PR DESCRIPTION
# Infra` Pull Request

## Designated for:

**CI/CD and tooling:**
- GitHub Actions workflows
- CI/CD pipelines
- build scripts
- deployment scripts
- repo automation (Dependabot config, labels, bots)
- lint/test pipeline configuration
- Docker build pipelines (if part of infra, not dependency update)
- tooling upgrades affecting workflow behavior

---

> ⚠️ Please ensure this PR is complete before requesting review:
> - Fill out all relevant sections
> - Ensure checkboxes reflect reality
> - Add required explanations where applicable

---

## 🧾 Summary

What infrastructure or tooling is being changed?

Added CI for providing instruction to PR comment for PRs created by dependabot (deps, vulnerabilities) 

---

## 🔧 What is changing

- CI workflow changes

---

## 🚨 Risk Assessment

- [x] Low risk (workflow formatting, minor config)
- [ ] Medium risk (pipeline step changes, dependency in CI)
- [ ] High risk (release/deploy changes, CI logic changes)

Explain risk:
- Added instruction by CI can be ignored by user. The instruction is only guideline not process blocker.
- CI has not been tested
---

## 🧪 Testing

- [ ] CI not tested yet
---

## 📏 Governance
- [x] PR title follows convention
- [x] Linked issue (e.g. `Closes #123`)
- [x] Self-review completed

Closes #65